### PR TITLE
Fix reveal observer on route changes to restore Status and Stack pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.next/
+node_modules/

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,6 +2,7 @@ import '../styles/globals.css';
 import Layout from '../components/Layout';
 import Head from 'next/head';
 import { useEffect } from 'react';
+import { useRouter } from 'next/router';
 
 /**
  * Custom App component to wrap all pages with the Layout. This
@@ -10,7 +11,11 @@ import { useEffect } from 'react';
  * untouched.
  */
 export default function MyApp({ Component, pageProps }) {
+  const router = useRouter();
+
   // Activamos las animaciones de aparición según scroll usando IntersectionObserver.
+  // Re‑inicializamos el observer cada vez que cambia la ruta para captar
+  // los nuevos elementos con clase `reveal` y evitar pantallas en blanco.
   useEffect(() => {
     const observer = new IntersectionObserver(
       (entries) => {
@@ -27,7 +32,7 @@ export default function MyApp({ Component, pageProps }) {
     return () => {
       elements.forEach((el) => observer.unobserve(el));
     };
-  }, []);
+  }, [router.asPath]);
 
   return (
     <>


### PR DESCRIPTION
## Summary
- reinitialize IntersectionObserver when navigating to reveal hidden sections
- ignore `.next` and `node_modules` directories

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b5cce13df08320b274c72b3990799b