### PR TITLE
Refine success stories and SEO audit page

### DIFF
--- a/pages/audits.js
+++ b/pages/audits.js
@@ -12,42 +12,65 @@ export default function Audits() {
     {
       emoji: '🧪',
       title: 'Análisis técnico',
-      points: ['Crawl y log analysis', 'Problemas de indexación y redirecciones'],
+      points: [
+        'Crawl y log analysis',
+        'Problemas de indexación y redirecciones',
+        'Revisión de sitemaps y robots.txt',
+      ],
     },
     {
       emoji: '📚',
       title: 'Arquitectura & enlaces',
-      points: ['Jerarquía de contenidos', 'Enlazado interno y páginas huérfanas'],
+      points: [
+        'Jerarquía de contenidos',
+        'Enlazado interno y páginas huérfanas',
+        'Canibalización y estructura de URLs',
+      ],
     },
     {
       emoji: '⚡',
       title: 'Rendimiento & CWV',
-      points: ['Medición de LCP, FID y CLS', 'Optimización de imágenes y scripts'],
+      points: [
+        'Medición de LCP, FID y CLS',
+        'Optimización de imágenes y scripts',
+        'Revisión de servidores y caché',
+      ],
     },
     {
       emoji: '✍️',
       title: 'On‑page & EEAT',
-      points: ['Optimización de títulos, metas y encabezados', 'Actualización de contenidos y EEAT'],
+      points: [
+        'Optimización de títulos, metas y encabezados',
+        'Actualización de contenidos y EEAT',
+        'Datos estructurados y rich snippets',
+      ],
     },
     {
       emoji: '🔗',
       title: 'Autoridad & enlaces',
-      points: ['Auditoría de backlinks y menciones', 'Oportunidades de PR digital'],
+      points: [
+        'Auditoría de backlinks y menciones',
+        'Oportunidades de PR digital',
+        'Evaluación de toxicidad de enlaces',
+      ],
     },
     {
       emoji: '🔍',
       title: 'Keyword research & SERP',
-      points: ['Investigación de términos y clusters', 'Análisis de SERP features y competidores'],
+      points: [
+        'Investigación de términos y clusters',
+        'Análisis de SERP features y competidores',
+        'Análisis de intención de búsqueda',
+      ],
     },
     {
       emoji: '🤖',
       title: 'SEO IA & GEO',
-      points: ['Preparación para motores generativos', 'Citas, datos estructurados y datasets abiertos'],
-    },
-    {
-      emoji: '📏',
-      title: 'KPIs & benchmarks',
-      points: ['Definición de métricas de éxito', 'Establecimiento de baseline comparativo'],
+      points: [
+        'Preparación para motores generativos',
+        'Citas, datos estructurados y datasets abiertos',
+        'Optimización para motores como SGE y Perplexity',
+      ],
     },
   ];
   return (

--- a/pages/index.js
+++ b/pages/index.js
@@ -52,12 +52,13 @@ export default function Home() {
         >
           <h1
             style={{
-              fontSize: 'clamp(32px, 5vw, 46px)',
+              fontSize: 'clamp(28px, 4vw, 40px)',
               fontWeight: 800,
               marginBottom: '12px',
               lineHeight: 1.2,
               opacity: 0,
               animation: 'fadeUp 0.8s ease forwards',
+              whiteSpace: 'nowrap',
             }}
           >
             Propuesta TUIO × Jorge J. Rolo

--- a/pages/kpis.js
+++ b/pages/kpis.js
@@ -14,9 +14,9 @@ export default function KPIs() {
       goal: '+50% en 6 meses',
     },
     {
-      name: 'Keywords en Top 10',
-      baseline: '300 términos',
-      goal: '+60% en 6 meses',
+      name: 'Índice de visibilidad',
+      baseline: '2.5 (hipotético)',
+      goal: '+50% en 6 meses',
     },
     {
       name: 'Menciones en LLM',

--- a/pages/success.js
+++ b/pages/success.js
@@ -27,7 +27,7 @@ export default function Success() {
         'Estrategia de link building y menciones en medios financieros.',
       ],
       // Resultados moderados y verosímiles
-      results: ['+35% keywords en Top 10', '+30% tráfico orgánico en 6 meses', '+25% leads orgánicos'],
+      results: ['+35% visibilidad orgánica', '+30% tráfico orgánico en 6 meses', '+25% leads orgánicos'],
     },
     {
       sector: 'Turismo',
@@ -92,7 +92,7 @@ export default function Success() {
                   alt={`Sector ${c.sector}`}
                   width={800}
                   height={400}
-                  style={{ borderRadius: '14px', width: '100%', height: 'auto' }}
+                  style={{ borderRadius: '14px', width: '100%', height: '400px', objectFit: 'contain' }}
                 />
                 <h3 style={{ marginTop: '14px' }}>{c.title}</h3>
                 <p style={{ fontSize: '14px' }}><strong>Objetivos:</strong> {c.objectives}</p>


### PR DESCRIPTION
## Summary
- Ensure success case images scale uniformly and replace "Keywords en Top 10" with visibility-focused metrics
- Remove KPI block from SEO audit section and expand key audit categories
- Adjust landing page title sizing so "Propuesta TUIO × Jorge J. Rolo" fits on one line

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5d8ad191483209f5c16cf41300cd3