### PR TITLE
Fix landing title wrapping on mobile

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -58,7 +58,7 @@ export default function Home() {
               lineHeight: 1.2,
               opacity: 0,
               animation: 'fadeUp 0.8s ease forwards',
-              whiteSpace: 'nowrap',
+              wordBreak: 'break-word',
             }}
           >
             Propuesta TUIO × Jorge J. Rolo


### PR DESCRIPTION
## Summary
- allow landing title to wrap for small screens

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5e5d620fc8320b1a05a68a5d74dd3