### PR TITLE
Improve success cases responsiveness

### DIFF
--- a/pages/success.js
+++ b/pages/success.js
@@ -81,11 +81,12 @@ export default function Success() {
           {cases.map((c, i) => (
             <div
               key={i}
-              style={{ width: `${100 / cases.length}%`, padding: '0 10%' }}
+              className="case-slide"
+              style={{ width: `${100 / cases.length}%` }}
             >
               <div
                 className="card"
-                style={{ maxWidth: '800px', margin: '0 auto', display: 'flex', flexDirection: 'column', height: '100%' }}
+                style={{ maxWidth: '1000px', margin: '0 auto', display: 'flex', flexDirection: 'column', height: '100%' }}
               >
                 <Image
                   src={c.img}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -229,6 +229,16 @@ section {
   color: var(--muted);
 }
 
+.case-slide {
+  padding: 0;
+}
+
+@media (min-width: 768px) {
+  .case-slide {
+    padding: 0 10%;
+  }
+}
+
 /* Timeline Steps */
 .timeline {
   display: grid;


### PR DESCRIPTION
## Summary
- Ensure success cases carousel takes full width on mobile by using a responsive `.case-slide` wrapper
- Increase card max width so desktop views use available space

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5e7e89e34832081493ae4224cab78