### PR TITLE
feat: sticky summary bar with translucent background

### DIFF
--- a/pages/investment.js
+++ b/pages/investment.js
@@ -73,7 +73,7 @@ export default function Investment() {
 
   return (
     <section className="reveal" style={{ paddingBottom: '180px' }}>
-      <h1>Inversión y selección de servicios</h1>
+      <h1>Propuesta económica por servicios</h1>
       <p>
         Selecciona los servicios que deseas contratar. Puedes elegir cada fase
         de manera individual o beneficiarte de descuentos al contratar todas las

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -367,13 +367,30 @@ summary::-webkit-details-marker {
   bottom: 0;
   width: 100%;
   padding: 14px 24px;
-  background: var(--panel);
-  border-top: 1px solid #e5e7eb;
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border-top: 1px solid rgba(229, 231, 235, 0.8);
   box-shadow: 0 -4px 10px rgba(0, 0, 0, 0.08);
   display: flex;
   justify-content: space-between;
   align-items: center;
   z-index: 100;
+}
+
+@media (max-width: 640px) {
+  .sticky-summary {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  .sticky-summary > div:last-child {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
 }
 
 /* Vertical timeline for roadmap */


### PR DESCRIPTION
## Summary
- rename services investment title to "Propuesta económica por servicios"
- enhance sticky summary bar with translucent background and mobile layout

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b627c5f94c8320a06d85ab959d0a7d